### PR TITLE
Julia v0.6 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - nightly
+  - 0.6
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4-
+julia 0.6
 IntArrays
 IndexableBitVectors

--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -23,7 +23,7 @@ size will be about `w * 5/4 * length` bits.
 
 See (Claude et al, 2012, doi:10.1007/978-3-642-34109-0_18) for more details.
 """
-struct WaveletMatrix{w,T<:Unsigned,B<:AbstractBitVector} <: AbstractVector{T}
+struct WaveletMatrix{w,T,B} <: AbstractVector{T} where {w,T<:Unsigned,B<:AbstractBitVector}
     bits::NTuple{w,B}
     nzeros::NTuple{w,Int}
     sps::Vector{Int}

--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -4,7 +4,7 @@ module WaveletMatrices
 
 export WaveletMatrix, getindex, rank, select, freq
 
-import Base: endof, length, size, sizeof, getindex, select
+import Base: endof, length, size, sizeof, select
 
 using IndexableBitVectors
 import IndexableBitVectors: rank
@@ -57,7 +57,7 @@ const default_bitvector = SucVector
 end
 
 @generated function (WaveletMatrix){T<:Unsigned}(data::AbstractVector{T}, w::Integer=sizeof(T) * 8)
-    return WaveletMatrix{w}(data)
+    return WaveletMatrix{w,T,default_bitvector}(data)
 end
 
 length(wm::WaveletMatrix) = length(wm.bits[1])
@@ -73,7 +73,7 @@ function sizeof{w}(wm::WaveletMatrix{w})
     return s
 end
 
-@inline function getindex{w,T}(wm::WaveletMatrix{w,T}, i::Int)
+@inline function Base.getindex{w,T}(wm::WaveletMatrix{w,T}, i::Int)
     if i < 0 || endof(wm) < i
         throw(BoundsError(i))
     end
@@ -96,7 +96,7 @@ end
     return ret
 end
 
-@inline function getindex{w,T}(wm::WaveletMatrix{w,T,SucVector}, i::Int)
+@inline function Base.getindex{w,T}(wm::WaveletMatrix{w,T,SucVector}, i::Int)
     if i < 0 || endof(wm) < i
         throw(BoundsError(i))
     end
@@ -119,7 +119,7 @@ end
     return ret
 end
 
-@inline getindex{w,T}(wm::WaveletMatrix{w,T}, i::Integer) = getindex(wm, convert(Int, i))
+@inline Base.getindex{w,T}(wm::WaveletMatrix{w,T}, i::Integer) = getindex(wm, convert(Int, i))
 
 function rank{w}(a::Unsigned, wm::WaveletMatrix{w}, i::Int)
     i = clamp(i, 0, endof(wm))

--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -27,7 +27,7 @@ struct WaveletMatrix{w,T,B} <: AbstractVector{T} where {w,T<:Unsigned,B<:Abstrac
     bits::NTuple{w,B}
     nzeros::NTuple{w,Int}
     sps::Vector{Int}
-    function WaveletMatrix(bits)
+    function WaveletMatrix{w,T,B}(bits) where {w,T<:Unsigned,B<:AbstractBitVector}
         @assert 1 ≤ w ≤ sizeof(T) * 8 ≤ 64
         @assert length(bits) == w
         nzeros = Int[]

--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -51,12 +51,12 @@ end
 
 const default_bitvector = SucVector
 
-function Base.call{w,T<:Unsigned}(::Type{WaveletMatrix{w}}, data::AbstractVector{T}; destructive::Bool=false)
+@generated function (WaveletMatrix{w}){w,T<:Unsigned}(data::AbstractVector{T}; destructive::Bool=false)
     bits = build(default_bitvector, data, w, destructive)
     return WaveletMatrix{w,T,default_bitvector}(bits)
 end
 
-function Base.call{T<:Unsigned}(::Type{WaveletMatrix}, data::AbstractVector{T}, w::Integer=sizeof(T) * 8)
+@generated function (WaveletMatrix){T<:Unsigned}(data::AbstractVector{T}, w::Integer=sizeof(T) * 8)
     return WaveletMatrix{w}(data)
 end
 

--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -23,7 +23,7 @@ size will be about `w * 5/4 * length` bits.
 
 See (Claude et al, 2012, doi:10.1007/978-3-642-34109-0_18) for more details.
 """
-struct WaveletMatrix{w,T,B} <: AbstractVector{T} where {w,T<:Unsigned,B<:AbstractBitVector}
+struct WaveletMatrix{w,T<:Unsigned,B<:AbstractBitVector} <: AbstractVector{T}
     bits::NTuple{w,B}
     nzeros::NTuple{w,Int}
     sps::Vector{Int}

--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -23,7 +23,7 @@ size will be about `w * 5/4 * length` bits.
 
 See (Claude et al, 2012, doi:10.1007/978-3-642-34109-0_18) for more details.
 """
-immutable WaveletMatrix{w,T<:Unsigned,B<:AbstractBitVector} <: AbstractVector{T}
+immutable struct WaveletMatrix{w,T<:Unsigned,B<:AbstractBitVector} <: AbstractVector{T}
     bits::NTuple{w,B}
     nzeros::NTuple{w,Int}
     sps::Vector{Int}

--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -47,18 +47,16 @@ struct WaveletMatrix{w,T<:Unsigned,B<:AbstractBitVector} <: AbstractVector{T}
         end
         return new(tuple(bits...), tuple(nzeros...), sps)
     end
+    function WaveletMatrix{w}(data::AbstractVector{T}; destructive::Bool=false) where {w, T<:Unsigned}
+       bits = build(default_bitvector, data, w, destructive)
+       return WaveletMatrix{w,T,default_bitvector}(bits)
+    end
+    function WaveletMatrix(data::AbstractVector{T}, w::Integer=sizeof(T) * 8) where {T <: Unsigned}
+       return WaveletMatrix{w}(data)
+    end
 end
 
 const default_bitvector = SucVector
-
-@generated function (WaveletMatrix{w}){w,T<:Unsigned}(data::AbstractVector{T}; destructive::Bool=false)
-    bits = build(default_bitvector, data, w, destructive)
-    return WaveletMatrix{w,T,default_bitvector}(bits)
-end
-
-@generated function (WaveletMatrix){T<:Unsigned}(data::AbstractVector{T}, w::Integer=sizeof(T) * 8)
-    return WaveletMatrix{w,T,default_bitvector}(data)
-end
 
 length(wm::WaveletMatrix) = length(wm.bits[1])
 size(wm::WaveletMatrix) = (length(wm),)

--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -23,7 +23,7 @@ size will be about `w * 5/4 * length` bits.
 
 See (Claude et al, 2012, doi:10.1007/978-3-642-34109-0_18) for more details.
 """
-immutable struct WaveletMatrix{w,T<:Unsigned,B<:AbstractBitVector} <: AbstractVector{T}
+struct WaveletMatrix{w,T<:Unsigned,B<:AbstractBitVector} <: AbstractVector{T}
     bits::NTuple{w,B}
     nzeros::NTuple{w,Int}
     sps::Vector{Int}


### PR DESCRIPTION
This PR contains type constructor syntax changes required by Julia v0.6 which break compatibility with Julia v0.5.

Tests run cleanly on my osx machine on v0.6:
```
julia> Pkg.test("WaveletMatrices")
INFO: Computing test dependencies for WaveletMatrices...
INFO: No packages to install, update or remove
INFO: Testing WaveletMatrices

WARNING: deprecated syntax "abstract Result" at /Users/timsw/.julia/v0.6/FactCheck/src/FactCheck.jl:46.
Use "abstract type Result end" instead.
WaveletMatrix
  > ordered
  > unordered
  > homogeneous
  > Vector{Uint64}
  > 2-bit encoding
  > 17-bit encoding
  > destructive
  > random
152393 facts verified.
INFO: WaveletMatrices tests passed
```