### PR TITLE
do not import Base: select

### DIFF
--- a/src/WaveletMatrices.jl
+++ b/src/WaveletMatrices.jl
@@ -5,7 +5,7 @@ module WaveletMatrices
 
 export WaveletMatrix, getindex, rank, select, freq
 
-import Base: lastindex, length, size, sizeof, select
+import Base: lastindex, length, size, sizeof
 
 using IndexableBitVectors
 import IndexableBitVectors: rank


### PR DESCRIPTION
`Base.select` does not exist, and an imported `select` is not used in the source code.
